### PR TITLE
Add docker suport

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+db
+client/node_modules
+server/node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Athenaeum
+A digital books library written with SvelteKit and Express.
+
+## Run the project using docker-compose
+This repository includes three examples options for running using docker-compose.
+
+<details>
+  <summary>1. Run apps in <strong>local development mode</strong>, on separate ports, without building anything.</summary>
+  
+  ```sh
+    docker-compose -f docker-compose.dev.yml up
+  ```
+  
+</details>
+
+<details>
+  <summary>2. Build and run apps in <strong>live/production mode</strong> on separate ports.</summary>
+  
+  ```sh
+    docker-compose up -d
+  ```
+  
+</details>
+
+
+<details>
+  <summary>3. Build and run apps in <strong>static/production mode</strong> under a single origin, using nginx as a reverse proxy.</summary>
+  
+  ```sh
+    docker-compose -f docker-compose.prod.yml up -d
+  ```
+  
+</details>

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:16-alpine as base
+WORKDIR /home/node/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+
+FROM base as build-node
+RUN npm install @sveltejs/adapter-node@next
+RUN sed -i "s#@sveltejs/adapter-auto#@sveltejs/adapter-node#" svelte.config.js
+RUN npm run build
+
+FROM base as build-static
+RUN npm install @sveltejs/adapter-static@next
+RUN sed -i "s#@sveltejs/adapter-auto#@sveltejs/adapter-static#" svelte.config.js
+RUN npm run build
+
+FROM node:16-alpine AS node
+WORKDIR /home/node/app
+COPY --from=build-node /home/node/app/build /home/node/app
+COPY package*.json ./
+ENV NODE_ENV="production"
+RUN npm install --production
+USER node
+EXPOSE 3000
+CMD ["node", "."]
+
+FROM nginx:stable-alpine AS static-web
+COPY --from=build-static /home/node/app/build /usr/share/nginx/html
+COPY default.conf /etc/nginx/conf.d/

--- a/client/default.conf
+++ b/client/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen       80;
+    server_name  localhost;
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+    }
+    location /api {
+        proxy_pass http://backend:5000;
+    }
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "client",
   "version": "0.0.1",
   "scripts": {
-    "dev": "svelte-kit dev",
+    "dev": "svelte-kit dev --host",
     "build": "svelte-kit build",
     "package": "svelte-kit package",
     "preview": "svelte-kit preview",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,29 @@
+version: '2.4'
+services:
+  client:
+    image: node:16-alpine3.14
+    environment:
+      NODE_ENV: "development"
+    working_dir: "/home/node/app"
+    ports:
+      - "3000:3000"
+    volumes:
+      - "./client:/home/node/app"
+      - "client_node_modules:/home/node/app/node_modules"
+    command: sh -c "chown node:node node_modules && npm i && npm run dev"
+  server:
+    image: node:16-alpine3.14
+    environment:
+      NODE_ENV: "development"
+    working_dir: "/home/node/app"
+    volumes:
+      - "./server:/home/node/app"
+      - "db:/home/node/app/db"
+      - "server_node_modules:/home/node/app/node_modules"
+    ports:
+      - "5000:5000"
+    command: sh -c "npm i && npm run dev"
+volumes:
+  db:
+  client_node_modules:
+  server_node_modules:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,19 @@
+version: '2.4'
+services:
+  web:
+    image: athenaeum-client:static-web
+    build:
+      context: ./client
+      target: static-web
+    ports:
+      - 80:80
+    depends_on:
+      backend:
+        condition: service_started
+  backend:
+    image: athenaeum-server
+    build: ./server
+    volumes:
+      - "db:/home/node/app/db"
+volumes:
+  db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '2.4'
+services:
+  client:
+    image: athenaeum-client:node
+    build:
+      context: ./client
+      target: node
+    ports:
+      - "3000:3000"
+  server:
+    image: athenaeum-server
+    build: ./server
+    volumes:
+      - "db:/home/node/app/db"
+    ports:
+      - "5000:5000"
+volumes:
+  db:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:16-alpine
+WORKDIR /home/node/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+VOLUME /home/node/app/db
+EXPOSE 5000
+ENTRYPOINT ["./entrypoint.sh"]
+CMD [ "node", "index.js" ]

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+chown node:node db
+#npx sequelize-cli db:migrate
+#npx sequelize-cli db:seed:all
+exec "$@"


### PR DESCRIPTION
This branch adds docker support, with three options for running using docker-compose.
1. Build and deploy instantly with each component on a separate port. (Ports 3000 & 5000)
   `docker-compose up`
2. Skip the build step to deploy even faster during development. (Ports 3000 & 5000)
   `docker-compose -f docker-compose.dev.yml up`
3. Build a static frontend from Svelte, with files served by nginx, and reverse proxy /api requests to the express backend, all under a single origin.  (Port 80)
   `docker-compose -f docker-compose.prod.yml up -d`

The `entrypoint.sh` script can be modified to automatically run sequelize-cli commands for bringing up the database at start.