### PR TITLE
Make delete button clickable and delete tagmappings

### DIFF
--- a/client/src/lib/components/_bookComponent.svelte
+++ b/client/src/lib/components/_bookComponent.svelte
@@ -1,18 +1,20 @@
 <script>
-    import {page} from '$app/stores'
+ import {page} from '$app/stores'
 
-    export let id;
+ export let id;
 
-    function navToBook(){
-        window.location.href = window.location.protocol + '//' + $page.url.host + '/book?id=' + id;
-    }
+ function navToBook(){
+     window.location.href = window.location.protocol + '//' + $page.url.host + '/book?id=' + id;
+ }
 </script>
-<div class='wrapper' style='' title={id} on:click={navToBook}>
-    <div>
-        <slot name='image'>no image</slot>
+<div>
+    <div class='wrapper' style='' title={id} on:click={navToBook}>
+        <div>
+            <slot name='image'>no image</slot>
+        </div>
+        <slot name='title'>no title</slot>
+        <br />
     </div>
-    <slot name='title'>no title</slot>
-    <br />
     <slot></slot>
 </div>
 

--- a/server/controllers/Books.js
+++ b/server/controllers/Books.js
@@ -81,6 +81,17 @@ const getBooks = async (req,res) =>{
 
 const deleteBook = async (req,res) => {
     console.log("deleting book with id: " + req.body.bookId);
+    let tagmappings = await models.Tagmapping.destroy({
+        where: {
+            bookId: req.body.bookId
+        }
+    }).then(() => {
+        console.log("Deleted tagmapping entry");
+    }).catch((err) => {
+        console.error("Error deleting tagmapping entry");
+        console.error(error);
+        res.status(500).end();
+    });
     let wrote = await models.Wrote.destroy({
         where: {
             bookId: req.body.bookId


### PR DESCRIPTION
This commit fixes the bug that made the delete button unclickabe due
to the individual book information link overlapping the button, and
taking precedence. It also deletes the tagmapping that corresponds to
the book being deleted.