### PR TITLE
Fix book edit and update in production

### DIFF
--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -92,9 +92,9 @@
  function handleFormSubmission(e, formSubmissionObj) {
      console.log(e);
      console.log(formSubmissionObj);
-     if (formSubmissionObj.func.name === "editBook")
+     if (formSubmissionObj.func === editBook)
          editBook(e, formSubmissionObj.arg);
-     else if (formSubmissionObj.func.name === "addBook")
+     else if (formSubmissionObj.func === addBook)
          addBook(e);
  }
 


### PR DESCRIPTION
When building for production, the code gets obfuscated. This caueses the edit and add book functions to not run, because the function references in formSubmissionobj are being checked via a hardcoded name.

This commit checks which function is which by checking whether the function references match, instead of checking them by name.